### PR TITLE
Configure "claimable for" from the module's init

### DIFF
--- a/src/ClaimsHatter.sol
+++ b/src/ClaimsHatter.sol
@@ -61,6 +61,24 @@ contract ClaimsHatter is HatsModule {
   bool internal _claimableFor;
 
   /*//////////////////////////////////////////////////////////////
+                            INITIALIZER
+    //////////////////////////////////////////////////////////////*/
+
+  /**
+   * @notice Sets up this instance with initial operational values
+   * @param _initData Packed initialization data with the following parameters:
+   *  initClaimableFor - If true, this hat will be claimable on behalf of an explicitly eligible wearer. Otherwise, it
+   * will be claimable only by the receiver, unless the enableClaimingFor function will be called.
+   */
+  function _setUp(bytes calldata _initData) internal override {
+    bool initClaimableFor = abi.decode(_initData, (bool));
+    if (initClaimableFor) {
+      _claimableFor = true;
+      emit ClaimingForChanged(hatId(), true);
+    }
+  }
+
+  /*//////////////////////////////////////////////////////////////
                             CONSTRUCTOR
   //////////////////////////////////////////////////////////////*/
 

--- a/test/ClaimsHatter.t.sol
+++ b/test/ClaimsHatter.t.sol
@@ -337,7 +337,7 @@ contract ClaimableFromInitClaimFor is HatCreatedClaimableForTest {
     vm.prank(admin1);
   }
 
-  function test_eligibleWearer_canBeClaimedFor() public {
+  function test_eligibleWearer_canBeClaimedFor_fromInit() public {
     // mock explicitly eligibility for claimer1
     mockEligibityCall(claimer1, claimerHat1, true, true);
     // attempt the claim from another address, expecting a transfer event when minted
@@ -349,7 +349,7 @@ contract ClaimableFromInitClaimFor is HatCreatedClaimableForTest {
     assertTrue(hats.isWearerOfHat(claimer1, claimerHat1));
   }
 
-  function test_ineligibleWearer_cannotBeClaimedFor() public {
+  function test_ineligibleWearer_cannotBeClaimedFor_fromInit() public {
     // attempt the claim from another address, expecting a revert
     vm.prank(bot);
     vm.expectRevert(ClaimsHatter_NotExplicitlyEligible.selector);
@@ -364,7 +364,7 @@ contract ClaimableFromInitClaimFor is HatCreatedClaimableForTest {
     hatter.claimHatFor(claimer1);
   }
 
-  function test_eligibleWearer_notClaimableFor_cannotBeClaimedFor() public {
+  function test_eligibleWearer_notClaimableFor_cannotBeClaimedFor_fromInit() public {
     // disable claiming for
     vm.prank(admin1);
     hatter.disableClaimingFor();

--- a/test/ClaimsHatter.t.sol
+++ b/test/ClaimsHatter.t.sol
@@ -333,8 +333,6 @@ contract ClaimableFromInitClaimFor is HatCreatedClaimableForTest {
     // mint hatterHat1 to hatter
     vm.prank(admin1);
     hats.mintHat(hatterHat1, address(hatter));
-    // enable claiming for
-    vm.prank(admin1);
   }
 
   function test_eligibleWearer_canBeClaimedFor_fromInit() public {


### PR DESCRIPTION
This PR adds the ability to set the claims hatter as "claimable for" from its initialization. 